### PR TITLE
fix: make file logging opt-in via ENABLE_LOGGING env var

### DIFF
--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -8,14 +8,16 @@ export class Logger {
   private logLevel: 'debug' | 'info' | 'warn' | 'error';
   private toolLogPath: string;
   private errorLogPath: string;
+  private fileLoggingEnabled: boolean;
 
   constructor(logDir: string, logLevel: 'debug' | 'info' | 'warn' | 'error' = 'info') {
     this.logDir = logDir;
     this.logLevel = logLevel;
     this.toolLogPath = join(logDir, 'tool-usage.log');
     this.errorLogPath = join(logDir, 'error.log');
+    this.fileLoggingEnabled = process.env.ENABLE_LOGGING === 'true';
 
-    if (!existsSync(logDir)) {
+    if (this.fileLoggingEnabled && !existsSync(logDir)) {
       mkdirSync(logDir, { recursive: true });
     }
   }
@@ -60,10 +62,12 @@ export class Logger {
 
     console.error(formatted.trim());
 
-    this.writeLog(this.toolLogPath, formatted);
+    if (this.fileLoggingEnabled) {
+      this.writeLog(this.toolLogPath, formatted);
 
-    if (level === 'error') {
-      this.writeLog(this.errorLogPath, formatted);
+      if (level === 'error') {
+        this.writeLog(this.errorLogPath, formatted);
+      }
     }
   }
 

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,4 +1,4 @@
-import { writeFileSync, appendFileSync, existsSync, mkdirSync } from 'fs';
+import { appendFileSync, existsSync, mkdirSync } from 'fs';
 import { join } from 'path';
 import { LogEntry } from '../types.js';
 import { sanitizeLogValue } from './sanitize.js';

--- a/tests/logger-opt-in.test.ts
+++ b/tests/logger-opt-in.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { existsSync, mkdirSync, appendFileSync } from 'fs';
+
+vi.mock('fs', () => ({
+  existsSync: vi.fn().mockReturnValue(false),
+  mkdirSync: vi.fn(),
+  appendFileSync: vi.fn(),
+}));
+
+describe('Logger opt-in file logging', () => {
+  const originalEnv = process.env.ENABLE_LOGGING;
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.mocked(existsSync).mockReturnValue(false);
+    vi.mocked(mkdirSync).mockClear();
+    vi.mocked(appendFileSync).mockClear();
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.ENABLE_LOGGING;
+    } else {
+      process.env.ENABLE_LOGGING = originalEnv;
+    }
+  });
+
+  it('should NOT create log directory when ENABLE_LOGGING is not set', async () => {
+    delete process.env.ENABLE_LOGGING;
+    const { Logger } = await import('../src/utils/logger.js');
+    new Logger('./logs', 'info');
+    expect(mkdirSync).not.toHaveBeenCalled();
+  });
+
+  it('should NOT write to log files when ENABLE_LOGGING is not set', async () => {
+    delete process.env.ENABLE_LOGGING;
+    const { Logger } = await import('../src/utils/logger.js');
+    const logger = new Logger('./logs', 'info');
+    logger.info('test-tool', 'some message');
+    expect(appendFileSync).not.toHaveBeenCalled();
+  });
+
+  it('should create log directory when ENABLE_LOGGING=true', async () => {
+    process.env.ENABLE_LOGGING = 'true';
+    const { Logger } = await import('../src/utils/logger.js');
+    new Logger('./logs', 'info');
+    expect(mkdirSync).toHaveBeenCalledWith('./logs', { recursive: true });
+  });
+
+  it('should write to log files when ENABLE_LOGGING=true', async () => {
+    process.env.ENABLE_LOGGING = 'true';
+    const { Logger } = await import('../src/utils/logger.js');
+    const logger = new Logger('./logs', 'info');
+    logger.info('test-tool', 'some message');
+    expect(appendFileSync).toHaveBeenCalled();
+  });
+
+  it('should NOT write to log files when ENABLE_LOGGING=false', async () => {
+    process.env.ENABLE_LOGGING = 'false';
+    const { Logger } = await import('../src/utils/logger.js');
+    const logger = new Logger('./logs', 'info');
+    logger.info('test-tool', 'some message');
+    expect(appendFileSync).not.toHaveBeenCalled();
+  });
+});

--- a/tests/logger-opt-in.test.ts
+++ b/tests/logger-opt-in.test.ts
@@ -5,6 +5,7 @@ vi.mock('fs', () => ({
   existsSync: vi.fn().mockReturnValue(false),
   mkdirSync: vi.fn(),
   appendFileSync: vi.fn(),
+  writeFileSync: vi.fn(),
 }));
 
 describe('Logger opt-in file logging', () => {


### PR DESCRIPTION
## Summary

- File logging now requires `ENABLE_LOGGING=true` environment variable to activate
- Without it, no `./logs` directory is created and no log files are written
- `console.error` (stderr) output remains always-on for MCP protocol compatibility
- Matches the opt-in logging pattern used in mongo-scout-mcp

Closes #42

## Test plan

- [x] 5 new tests in `tests/logger-opt-in.test.ts` covering all scenarios
- [x] Full test suite passes (431 tests)