### PR TITLE
chore: bump version to 1.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postgres-scout-mcp",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Scout your PostgreSQL databases with AI - A production-ready MCP server with safety features, monitoring, and data quality tools",
   "main": "dist/index.js",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -2,14 +2,14 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-16/server.schema.json",
   "name": "io.github.bluwork/postgres-scout-mcp",
   "description": "Scout your PostgreSQL databases with AI - safety features, monitoring, and data quality",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "packages": [
     {
       "identifier": "postgres-scout-mcp",
       "registryBaseUrl": "https://registry.npmjs.org",
       "registryType": "npm",
       "transport": { "type": "stdio" },
-      "version": "1.0.2",
+      "version": "1.0.3",
       "packageArguments": [
         {
           "description": "Server mode: read-only (default) or read-write",


### PR DESCRIPTION
## Summary

- Bump version to 1.0.3 in `package.json` and `server.json` for npm republish
- Includes opt-in logging fix from #42

## Test plan

- [x] Build passes
- [x] All 431 tests pass